### PR TITLE
fix: use patchright to install chromium in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,6 +32,6 @@ jobs:
       - name: Install dependencies
         run: |
           pip install -e brow/[dev]
-          playwright install --with-deps chromium
+          python -m patchright install --with-deps chromium
       - name: Run tests
         run: pytest brow/tests/ -v


### PR DESCRIPTION
## Summary
- CI was failing because `playwright install` command doesn't exist — the project uses `patchright` (a Playwright fork)
- Changed to `python -m patchright install --with-deps chromium`

## Test plan
- [ ] CI passes on this PR