### PR TITLE
feat: add py.typed marker and ruff to dev deps

### DIFF
--- a/brow/pyproject.toml
+++ b/brow/pyproject.toml
@@ -25,6 +25,7 @@ dev = [
     "pytest>=7.0",
     "pytest-asyncio>=0.23",
     "httpx>=0.25",
+    "ruff>=0.4",
 ]
 
 [project.scripts]


### PR DESCRIPTION
## Summary
- Adds `py.typed` marker (PEP 561) so type checkers resolve types from the package
- Adds `ruff>=0.4` to `[project.optional-dependencies] dev` for consistency with CI and CONTRIBUTING.md

## Test plan
- [ ] CI passes
- [ ] `pip install -e brow/[dev]` includes ruff