### PR TITLE
chore: upgrade GitHub Actions versions, update gitignore

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -18,18 +18,18 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
         with:
-          node-version: '20'
+          node-version: '22'
           cache: npm
           cache-dependency-path: website/package-lock.json
       - name: Install dependencies
         run: cd website && npm ci
       - name: Build
         run: cd website && npm run build
-      - uses: actions/configure-pages@v4
-      - uses: actions/upload-pages-artifact@v3
+      - uses: actions/configure-pages@v5
+      - uses: actions/upload-pages-artifact@v4
         with:
           path: website/dist
 
@@ -41,4 +41,4 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,8 +10,8 @@ jobs:
     permissions:
       id-token: write
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.11"
       - name: Build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,8 +10,8 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.13"
       - run: pip install ruff
@@ -25,8 +25,8 @@ jobs:
       matrix:
         python-version: ["3.12", "3.13"]
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies

--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,5 @@ website/node_modules/
 website/dist/
 website/.astro/
 .superpowers/
+benchmarks/results_*/
+benchmarks/results/new-tasks-run/


### PR DESCRIPTION
## Summary
- Upgrades all GitHub Actions to Node 24-compatible versions (suppresses deprecation warnings):
  - `actions/checkout` v4 → v5
  - `actions/setup-python` v5 → v6
  - `actions/setup-node` v4 → v5
  - `actions/configure-pages` v4 → v5
  - `actions/upload-pages-artifact` v3 → v4
  - `actions/deploy-pages` v4 → v5
- Uses Node 22 for docs build (Node 20 EOL approaching)
- Adds benchmark run artifact dirs to `.gitignore`

## Test plan
- [ ] CI passes without Node.js deprecation warnings
- [ ] Docs deploy still works